### PR TITLE
Template team

### DIFF
--- a/_includes/foot.html
+++ b/_includes/foot.html
@@ -1,0 +1,10 @@
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/uswds/2.11.1/js/uswds.min.js"></script>
+
+    <!-- Google Analytics: change UA-XXXXX-Y to be your site's ID. -->
+    <script>
+        window.ga = function () { ga.q.push(arguments) }; ga.q = []; ga.l = +new Date;
+        ga('create', '{{ site.ga }}', 'auto'); ga('set', 'anonymizeIp', true); ga('set', 'transport', 'beacon'); ga('send', 'pageview')
+    </script>
+    <script src="https://www.google-analytics.com/analytics.js" async></script>
+    </body>
+</html>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,129 @@
+<footer class="usa-footer">
+    <div class="grid-container usa-footer__return-to-top">
+      <a href="#">Return to top</a>
+    </div>
+    <div class="usa-footer__primary-section">
+      <nav class="usa-footer__nav" aria-label="Footer navigation">
+        <ul class="grid-row grid-gap">
+          <li class="mobile-lg:grid-col-3 desktop:grid-col-auto usa-footer__primary-content">
+            <a class="usa-footer__primary-link" href="javascript:void(0);">Home</a>
+          </li>
+          <li class="mobile-lg:grid-col-3 desktop:grid-col-auto usa-footer__primary-content">
+            <a class="usa-footer__primary-link" href="javascript:void(0);">Topics</a>
+          </li>
+          <li class="mobile-lg:grid-col-3 desktop:grid-col-auto usa-footer__primary-content">
+            <a class="usa-footer__primary-link" href="javascript:void(0);">Agency</a>
+          </li>
+          <li class="mobile-lg:grid-col-3 desktop:grid-col-auto usa-footer__primary-content">
+            <a class="usa-footer__primary-link" href="javascript:void(0);">Media</a>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  
+    <div class="usa-footer__secondary-section">
+      <div class="grid-container">
+        <div class="grid-row grid-gap">
+          <div class="usa-footer__logo grid-row mobile-lg:grid-col-6 mobile-lg:grid-gap-2">
+            <div class="mobile-lg:grid-col-auto">
+              <img class="usa-footer__logo-img" src="https://raw.githubusercontent.com/Bixal/rrt-content/main/assets/img/Logo_USAGov.png" alt="USA.gov logo">
+            </div>
+            <div class="mobile-lg:grid-col-auto">
+              <p class="usa-footer__logo-heading">Agency.gov</p>
+            </div>
+          </div>
+          <div class="usa-footer__contact-links mobile-lg:grid-col-6">
+            <div class="usa-footer__social-links grid-row grid-gap-1">
+              <div class="grid-col-auto">
+                <a class="usa-social-link usa-social-link--facebook" href="javascript:void(0);">
+                  <span>Facebook</span>
+                </a>
+              </div>
+              <div class="grid-col-auto">
+                <a class="usa-social-link usa-social-link--twitter" href="javascript:void(0);">
+                  <span>Twitter</span>
+                </a>
+              </div>
+              <div class="grid-col-auto">
+                <a class="usa-social-link usa-social-link--youtube" href="javascript:void(0);">
+                  <span>YouTube</span>
+                </a>
+              </div>
+              <div class="grid-col-auto">
+                <a class="usa-social-link usa-social-link--instagram" href="javascript:void(0);">
+                  <span>Instagram</span>
+                </a>
+              </div>
+              <div class="grid-col-auto">
+                <a class="usa-social-link usa-social-link--rss" href="javascript:void(0);">
+                  <span>RSS</span>
+                </a>
+              </div>
+            </div>
+            <h3 class="usa-footer__contact-heading">Agency Contact Center</h3>
+            <address class="usa-footer__address">
+              <div class="usa-footer__contact-info grid-row grid-gap">
+                <div class="grid-col-auto">
+                  <a href="tel:1-800-555-5555">(800) CALL-GOVT</a>
+                </div>
+                <div class="grid-col-auto">
+                  <a href="mailto:info@agency.gov">info@agency.gov</a>
+                </div>
+                <div class="grid-col-auto">
+                  <a href="javascript:void(0);">Translate</a>
+                </div>
+              </div>
+            </address>
+          </div>
+        </div>
+      </div>
+    </div>
+  </footer>
+  <div class="usa-identifier">
+    <section class="usa-identifier__section usa-identifier__section--masthead" aria-label="Agency identifier">
+      <div class="usa-identifier__container">
+        <div class="usa-identifier__logos">
+          <a href="javascript:void(0);" class="usa-identifier__logo">
+            <img class="usa-identifier__logo-img" src="https://raw.githubusercontent.com/Bixal/rrt-content/main/assets/img/Logo_USAGov.png" alt="USA.gov logo" role="img">
+          </a>
+        </div>
+        <div class="usa-identifier__identity" aria-label="Agency description">
+          <p class="usa-identifier__identity-domain">agency.gov</p>
+          <p class="usa-identifier__identity-disclaimer">An official website of the <a href="javascript:void(0);">Agency</a></p>
+        </div>
+      </div>
+    </section>
+    <nav class="usa-identifier__section usa-identifier__section--required-links" aria-label="Important links">
+      <div class="usa-identifier__container">
+        <ul class="usa-identifier__required-links-list">
+          <li class="usa-identifier__required-links-item">
+            <a href="javascript:void(0);" class="usa-identifier__required-link">About Agency.gov</a>
+          </li>
+          <li class="usa-identifier__required-links-item">
+            <a href="javascript:void(0);" class="usa-identifier__required-link">Accessibility support</a>
+          </li>
+          <li class="usa-identifier__required-links-item">
+            <a href="javascript:void(0);" class="usa-identifier__required-link usa-link">FOIA requests</a>
+          </li>
+          <li class="usa-identifier__required-links-item">
+            <a href="javascript:void(0);" class="usa-identifier__required-link usa-link">No FEAR Act data</a>
+          </li>
+          <li class="usa-identifier__required-links-item">
+            <a href="javascript:void(0);" class="usa-identifier__required-link usa-link">Office of the Inspector General</a>
+          </li>
+          <li class="usa-identifier__required-links-item">
+            <a href="javascript:void(0);" class="usa-identifier__required-link usa-link">Performance reports</a>
+          </li>
+          <li class="usa-identifier__required-links-item">
+            <a href="javascript:void(0);" class="usa-identifier__required-link usa-link">Privacy policy</a>
+          </li>
+        </ul>
+      </div>
+    </nav>
+    <section class="usa-identifier__section usa-identifier__section--usagov" aria-label="U.S. government information and services">
+      <div class="usa-identifier__container">
+        <div class="usa-identifier__usagov-description">Looking for U.S. government information and services?</div>
+        <a href="https://www.usa.gov/" class="usa-link">Visit USA.gov</a>
+      </div>
+    </section>
+  </div>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,11 @@
+<html class="no-js" lang="{{site.lang}}">
+<head>
+    <meta charset="utf-8">
+    <title>{{ site.title }}</title>
+    <meta name="description" content="{{ site.description }}">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/uswds/2.11.1/js/uswds-init.min.js" integrity="sha512-Zy/dqU71uCdMWS6VdSqc/+2RjOxbq/ySinrQyLG3wTVWSXtBQpK6/b2Ky6vT2JHuFsNm8yBZMJ8zeMQ/ji2qMA==" crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/uswds/2.11.1/css/uswds.min.css" integrity="sha512-jTdlH2LXTQ/nSPgY0SoocLYibqnSu0B7/DM2cmA3jPrw89dbtZKeytKXDJPYlZpjkHfHUlTe/4MTGovdM73AJw==" crossorigin="anonymous" />
+    <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/custom.css">
+  </head>

--- a/_includes/header-extended.html
+++ b/_includes/header-extended.html
@@ -1,0 +1,155 @@
+<a class="usa-skipnav" href="#main-content">Skip to main content</a>
+<section class="usa-banner" aria-label="Official government website">
+  <div class="usa-accordion">
+    <header class="usa-banner__header">
+      <div class="usa-banner__inner">
+        <div class="grid-col-auto">
+          <img class="usa-banner__header-flag" src="https://cdnjs.cloudflare.com/ajax/libs/uswds/2.11.1/img/us_flag_small.png" alt="U.S. flag">
+        </div>
+        <div class="grid-col-fill tablet:grid-col-auto">
+          <p class="usa-banner__header-text">An official website of the United States government</p>
+          <p class="usa-banner__header-action" aria-hidden="true">Here’s how you know</p>
+        </div>
+        <button class="usa-accordion__button usa-banner__button" aria-expanded="false" aria-controls="gov-banner">
+          <span class="usa-banner__button-text">Here’s how you know</span>
+        </button>
+      </div>
+    </header>
+    <div class="usa-banner__content usa-accordion__content" id="gov-banner">
+      <div class="grid-row grid-gap-lg">
+        <div class="usa-banner__guidance tablet:grid-col-6">
+          <img class="usa-banner__icon usa-media-block__img" src="https://cdnjs.cloudflare.com/ajax/libs/uswds/2.11.1/img/icon-dot-gov.svg" role="img" alt="" aria-hidden="true">
+          <div class="usa-media-block__body">
+            <p>
+              <strong>
+                Official websites use .gov
+              </strong>
+              <br />
+              A <strong>.gov</strong> website belongs to an official government organization in the United States.
+
+            </p>
+          </div>
+        </div>
+        <div class="usa-banner__guidance tablet:grid-col-6">
+          <img class="usa-banner__icon usa-media-block__img" src="https://cdnjs.cloudflare.com/ajax/libs/uswds/2.11.1/img/icon-https.svg" role="img" alt="" aria-hidden="true">
+          <div class="usa-media-block__body">
+            <p>
+              <strong>
+                Secure .gov websites use HTTPS
+              </strong>
+              <br />
+              A <strong>lock</strong> (
+              <span class="icon-lock"><svg xmlns="http://www.w3.org/2000/svg" width="52" height="64" viewBox="0 0 52 64" class="usa-banner__lock-image" role="img" aria-labelledby="banner-lock-title banner-lock-description" focusable="false">
+                  <title id="banner-lock-title">Lock</title>
+                  <desc id="banner-lock-description">A locked padlock</desc>
+                  <path fill="#000000" fill-rule="evenodd" d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z" />
+                </svg></span>
+              ) or <strong>https://</strong> means you’ve safely connected to the .gov website. Share sensitive information only on official, secure websites.
+
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<div class="usa-overlay"></div>
+<header class="usa-header usa-header--extended">
+  <div class="usa-navbar">
+    <div class="usa-logo" id="extended-logo">
+      <em class="usa-logo__text"><a href="/" title="Home" aria-label="Home">Agency.gov</a></em>
+    </div>
+    <button class="usa-menu-btn">Menu</button>
+  </div>
+  <nav aria-label="Primary navigation" class="usa-nav">
+    <div class="usa-nav__inner"><button class="usa-nav__close"><img src="https://cdnjs.cloudflare.com/ajax/libs/uswds/2.11.1/img/usa-icons/close.svg" role="img" alt="close"></button>
+      <ul class="usa-nav__primary usa-accordion">
+        <li class="usa-nav__primary-item">
+          <a class="usa-nav__link usa-current" href="javascript:void(0)"><span>Home</span></a>
+        </li>
+        <li class="usa-nav__primary-item">
+          <button class="usa-accordion__button usa-nav__link" aria-expanded="false" aria-controls="extended-nav-section-one"><span>Topics</span></button>
+          <ul id="extended-nav-section-one" class="usa-nav__submenu">
+            <li class="usa-nav__submenu-item">
+              <a href="javascript:void(0);" class="">Benefits</a>
+            </li>
+            <li class="usa-nav__submenu-item">
+              <a href="javascript:void(0);" class="">Grants and loans</a>
+            </li>
+            <li class="usa-nav__submenu-item">
+              <a href="javascript:void(0);" class="">Financial aid for students</a>
+            </li>
+            <li class="usa-nav__submenu-item">
+              <a href="javascript:void(0);" class="">Unemployment help</a>
+            </li>
+            <li class="usa-nav__submenu-item">
+              <a href="javascript:void(0);" class="">Military programs and benefits</a>
+            </li>
+          </ul>
+        </li>
+        <li class="usa-nav__primary-item">
+          <button class="usa-accordion__button usa-nav__link" aria-expanded="false" aria-controls="extended-nav-section-two"><span>Agency</span></button>
+          <ul id="extended-nav-section-two" class="usa-nav__submenu">
+            <li class="usa-nav__submenu-item">
+              <a href="javascript:void(0);" class="">About us</a>
+            </li>
+            <li class="usa-nav__submenu-item">
+              <a href="javascript:void(0);" class="">Initiatives</a>
+            </li>
+            <li class="usa-nav__submenu-item">
+              <a href="javascript:void(0);" class="">Divisions</a>
+            </li>
+            <li class="usa-nav__submenu-item">
+              <a href="javascript:void(0);" class="">Careers</a>
+            </li>
+            <li class="usa-nav__submenu-item">
+              <a href="javascript:void(0);" class="">Offices</a>
+            </li>
+          </ul>
+        </li>
+        <li class="usa-nav__primary-item">
+          <button class="usa-accordion__button usa-nav__link" aria-expanded="false" aria-controls="extended-nav-section-three"><span>Media</span></button>
+          <ul id="extended-nav-section-three" class="usa-nav__submenu">
+            <li class="usa-nav__submenu-item">
+              <a href="javascript:void(0);" class="">Blog</a>
+            </li>
+            <li class="usa-nav__submenu-item">
+              <a href="javascript:void(0);" class="">Social</a>
+            </li>
+            <li class="usa-nav__submenu-item">
+              <a href="javascript:void(0);" class="">Press releases</a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+      <div class="usa-nav__secondary">
+        <ul class="usa-nav__secondary-links">
+          <li class="usa-nav__secondary-item">
+            <svg class="usa-icon text-base" aria-hidden="true" role="img">
+              <use xlink:href="#language"></use>
+            </svg>
+            <a href="javascript:void(0);">Translate</a>
+          </li>
+          <li class="usa-nav__secondary-item">
+            <svg class="usa-icon text-base" aria-hidden="true" role="img">
+              <use xlink:href="#mail_outline"></use>
+            </svg>
+            <a href="javascript:void(0);">Subscribe</a>
+          </li>
+          <li class="usa-nav__secondary-item">
+            <svg class="usa-icon text-base" aria-hidden="true" role="img">
+              <use xlink:href="#phone"></use>
+            </svg>
+            <a href="javascript:void(0);">Contact</a>
+          </li>
+        </ul>
+        <form class="usa-search usa-search--small" role="search">
+          <label class="usa-sr-only" for="extended-search-field-small">Search small</label>
+          <input class="usa-input" id="extended-search-field-small" type="search" name="search">
+          <button class="usa-button" type="submit"><span class="usa-sr-only">Search</span></button>
+        </form>
+      </div>
+    </div>
+  </nav>
+</header>

--- a/_layouts/team.html
+++ b/_layouts/team.html
@@ -5,18 +5,16 @@
 <body>
   {% include header-extended.html %}
 
-  <main>
+  <main id="main-content">
     <div class="grid-container padding-y-2">
       <h1>{{ page.title }}</h1>
       {{ content }}
-      <div class="grid-row">
+      <div class="grid-row grid-gap">
         {% for member in page.members %}
-        <div class="mobile-lg:grid-col-6 tablet:grid-col-4 text-center margin-bottom-3 padding-1">
-          <img src="{{ member.image }}" alt="{{ member.name }}" class="radius-lg">
+        <div class="mobile-lg:grid-col-6 tablet:grid-col-4 margin-bottom-3 padding-1">
+          <img src="{{ member.image }}" alt="Portrait of {{ member.name }}" class="radius-lg">
           <h2 class="margin-bottom-0 margin-y-1">{{ member.name }}</h2>
-          <p class="margin-top-0">{{ member.title }}<br>
-            <a href="{{ member.email }}" class="usa-link">{{ member.email }}</a>
-          </p> 
+          <p class="margin-top-0">{{ member.title }}</p> 
         </div>
         {% endfor %}
       </div>

--- a/_layouts/team.html
+++ b/_layouts/team.html
@@ -1,0 +1,27 @@
+<!doctype html>
+
+{% include head.html %}
+
+<body>
+  {% include header-extended.html %}
+
+  <main>
+    <div class="grid-container padding-y-2">
+      <h1>{{ page.title }}</h1>
+      {{ content }}
+      <div class="grid-row">
+        {% for member in page.members %}
+        <div class="mobile-lg:grid-col-6 tablet:grid-col-4 text-center margin-bottom-3 padding-1">
+          <img src="{{ member.image }}" alt="{{ member.name }}" class="radius-lg">
+          <h2 class="margin-bottom-0 margin-y-1">{{ member.name }}</h2>
+          <p class="margin-top-0">{{ member.title }}<br>
+            <a href="{{ member.email }}" class="usa-link">{{ member.email }}</a>
+          </p> 
+        </div>
+        {% endfor %}
+      </div>
+    </div>
+  </main>
+
+  {% include footer.html %}
+  {% include foot.html %}

--- a/_layouts/team.html
+++ b/_layouts/team.html
@@ -18,6 +18,7 @@
         </div>
         {% endfor %}
       </div>
+      <p>Source: <a href="{{ page.source-url }}" class="usa-link">{{ page.source-domain }}</a></p>
     </div>
   </main>
 

--- a/team.md
+++ b/team.md
@@ -3,22 +3,33 @@ layout: team
 title: Team
 description: Key team members with name, email, and a feature photo
 members:
-    - name: Lloyd Austin
-      title: Secretary of Defense
-      email: lloyd.austin@defense.gov
-      image: https://bixal.github.io/rrt-content/assets/img/Bio-LeftonAmanda.jpg
-    - name: Merrick Garland
-      title: Attorney General
-      email: merrick.garland@doj.gov
-      image: https://bixal.github.io/rrt-content/assets/img/Bio-LeftonAmanda.jpg
-    - name: Deb Haaland
-      title: Secretary of the Interior
-      email: deb.haaland@interior.gov
-      image: https://bixal.github.io/rrt-content/assets/img/Bio-LeftonAmanda.jpg
-    - name: Kamala Harris
-      title: Vice President
-      email: kamala.harris@whitehouse.gov
-      image: https://bixal.github.io/rrt-content/assets/img/Bio-LeftonAmanda.jpg
+    - name: Marcia Fudge
+      title: Secretary of Housing and Urban Development
+      image: https://www.whitehouse.gov/wp-content/uploads/2021/01/Marcia_Fudge.jpg
+    - name: Pete Buttigieg
+      title: Secretary of Transportation
+      image: https://www.whitehouse.gov/wp-content/uploads/2021/01/Pete_Buttigieg.jpg
+    - name: Alejandro Mayorkas
+      title: Secretary of Homeland Security
+      image: https://www.whitehouse.gov/wp-content/uploads/2021/01/Alejandro_Mayorkas.jpg
+    - name: Michael Regan
+      title: Administrator of the Environmental Protection Agency
+      image: https://www.whitehouse.gov/wp-content/uploads/2021/01/Michael_Regan.jpg
+    - name: Katherine Tai
+      title: United States Trade Representative
+      image: https://www.whitehouse.gov/wp-content/uploads/2021/01/Katherine_Tai.jpg
+    - name: Linda Thomas-Greenfield
+      title: United States Ambassador to the United Nations
+      image: https://www.whitehouse.gov/wp-content/uploads/2021/01/Linda_Thomas-Greenfield.jpg
+    - name: Dr. Cecilia Rouse
+      title: Chair of the Council of Economic Advisers
+      image: https://www.whitehouse.gov/wp-content/uploads/2021/01/Cecilia_Rouse.jpg
+    - name: Isabel Guzman
+      title: Administrator of the Small Business Administration
+      image: https://www.whitehouse.gov/wp-content/uploads/2021/01/Isabel_Guzman.jpg
 ---
 
 The Cabinet’s role is to advise the President on any subject he or she may require relating to the duties of each member’s respective office.
+{: .usa-intro}
+
+President Biden’s Cabinet reflects his pledge to appoint leaders of government agencies that reflect the country they aim to serve.

--- a/team.md
+++ b/team.md
@@ -27,6 +27,8 @@ members:
     - name: Isabel Guzman
       title: Administrator of the Small Business Administration
       image: https://www.whitehouse.gov/wp-content/uploads/2021/01/Isabel_Guzman.jpg
+source-domain: whitehouse.gov
+source-url: https://www.whitehouse.gov/administration/cabinet/
 ---
 
 The Cabinet’s role is to advise the President on any subject he or she may require relating to the duties of each member’s respective office.

--- a/team.md
+++ b/team.md
@@ -1,0 +1,24 @@
+---
+layout: team
+title: Team
+description: Key team members with name, email, and a feature photo
+members:
+    - name: Lloyd Austin
+      title: Secretary of Defense
+      email: lloyd.austin@defense.gov
+      image: https://bixal.github.io/rrt-content/assets/img/Bio-LeftonAmanda.jpg
+    - name: Merrick Garland
+      title: Attorney General
+      email: merrick.garland@doj.gov
+      image: https://bixal.github.io/rrt-content/assets/img/Bio-LeftonAmanda.jpg
+    - name: Deb Haaland
+      title: Secretary of the Interior
+      email: deb.haaland@interior.gov
+      image: https://bixal.github.io/rrt-content/assets/img/Bio-LeftonAmanda.jpg
+    - name: Kamala Harris
+      title: Vice President
+      email: kamala.harris@whitehouse.gov
+      image: https://bixal.github.io/rrt-content/assets/img/Bio-LeftonAmanda.jpg
+---
+
+The Cabinet’s role is to advise the President on any subject he or she may require relating to the duties of each member’s respective office.

--- a/team.md
+++ b/team.md
@@ -5,28 +5,28 @@ description: Key team members with name, email, and a feature photo
 members:
     - name: Marcia Fudge
       title: Secretary of Housing and Urban Development
-      image: https://www.whitehouse.gov/wp-content/uploads/2021/01/Marcia_Fudge.jpg
+      image: https://bixal.github.io/rrt-content/assets/img/Marcia_Fudge.jpeg
     - name: Pete Buttigieg
       title: Secretary of Transportation
-      image: https://www.whitehouse.gov/wp-content/uploads/2021/01/Pete_Buttigieg.jpg
+      image: https://bixal.github.io/rrt-content/assets/img/Pete_Buttigieg.jpeg
     - name: Alejandro Mayorkas
       title: Secretary of Homeland Security
-      image: https://www.whitehouse.gov/wp-content/uploads/2021/01/Alejandro_Mayorkas.jpg
+      image: https://bixal.github.io/rrt-content/assets/img/Alejandro_Mayorkas.jpeg
     - name: Michael Regan
       title: Administrator of the Environmental Protection Agency
-      image: https://www.whitehouse.gov/wp-content/uploads/2021/01/Michael_Regan.jpg
+      image: https://bixal.github.io/rrt-content/assets/img/Michael_Regan.jpeg
     - name: Katherine Tai
       title: United States Trade Representative
-      image: https://www.whitehouse.gov/wp-content/uploads/2021/01/Katherine_Tai.jpg
+      image: https://bixal.github.io/rrt-content/assets/img/Katherine_Tai.jpeg
     - name: Linda Thomas-Greenfield
       title: United States Ambassador to the United Nations
-      image: https://www.whitehouse.gov/wp-content/uploads/2021/01/Linda_Thomas-Greenfield.jpg
+      image: https://bixal.github.io/rrt-content/assets/img/Linda_Thomas-Greenfield.jpeg
     - name: Dr. Cecilia Rouse
       title: Chair of the Council of Economic Advisers
-      image: https://www.whitehouse.gov/wp-content/uploads/2021/01/Cecilia_Rouse.jpg
+      image: https://bixal.github.io/rrt-content/assets/img/Cecilia_Rouse.jpeg
     - name: Isabel Guzman
       title: Administrator of the Small Business Administration
-      image: https://www.whitehouse.gov/wp-content/uploads/2021/01/Isabel_Guzman.jpg
+      image: https://bixal.github.io/rrt-content/assets/img/Isabel_Guzman.jpeg
 source-domain: whitehouse.gov
 source-url: https://www.whitehouse.gov/administration/cabinet/
 ---


### PR DESCRIPTION
Here's a draft of the Team template.

Some things to note:

- All the content is in the markdown file, either as structured content in the front matter or rich text in the content area.
- I decided to leave the email out because they can get tricky with the responsive grid, and the example I pulled from had name and title only.
- The content was chosen based on the availability of the same sized images (600x500). For some reason, they're not all the same.
- I referenced About Us template, but went with just grid for layout instead of media object. I don't think they need to be the same for now. But we can revisit later.
- The images are referencing the source location for now, but I'll move them to the rrt-content repo and reference them from there if everything else looks good.

Closes #37