### PR TITLE
Feature breadcrumb component

### DIFF
--- a/_includes/breadcrumb.html
+++ b/_includes/breadcrumb.html
@@ -1,0 +1,19 @@
+<nav class="usa-breadcrumb" aria-label="Breadcrumbs">
+    <ol class="usa-breadcrumb__list">
+        <li class="usa-breadcrumb__list-item">
+            <a href="{{ site.baseurl }}/" class="usa-breadcrumb__link">
+                <span>Home</span>
+            </a>
+        </li>
+        {% for item in page.breadcrumbs %}
+        <li class="usa-breadcrumb__list-item">
+            <a href="{{ site.baseurl }}/{{ item.url }}" class="usa-breadcrumb__link">
+                <span>{{ item.name }}</span>
+            </a>
+        </li>
+        {% endfor %}
+        <li class="usa-breadcrumb__list-item usa-current" aria-current="page">
+            <span>{{ page.title }}</span>
+        </li>
+    </ol>
+</nav>

--- a/_layouts/team.html
+++ b/_layouts/team.html
@@ -7,6 +7,7 @@
 
   <main id="main-content">
     <div class="grid-container padding-y-2">
+      {% include breadcrumb.html %}
       <h1>{{ page.title }}</h1>
       {{ content }}
       <div class="grid-row grid-gap">

--- a/team.md
+++ b/team.md
@@ -29,6 +29,11 @@ members:
       image: https://bixal.github.io/rrt-content/assets/img/Isabel_Guzman.jpeg
 source-domain: whitehouse.gov
 source-url: https://www.whitehouse.gov/administration/cabinet/
+breadcrumbs:
+  - name: Agency
+    url: agency.html
+  - name: Leadership
+    url: about-us/leadership.html
 ---
 
 The Cabinet’s role is to advise the President on any subject he or she may require relating to the duties of each member’s respective office.

--- a/team.md
+++ b/team.md
@@ -3,30 +3,30 @@ layout: team
 title: Team
 description: Key team members with name, email, and a feature photo
 members:
-    - name: Marcia Fudge
-      title: Secretary of Housing and Urban Development
-      image: https://bixal.github.io/rrt-content/assets/img/Marcia_Fudge.jpeg
-    - name: Pete Buttigieg
-      title: Secretary of Transportation
-      image: https://bixal.github.io/rrt-content/assets/img/Pete_Buttigieg.jpeg
-    - name: Alejandro Mayorkas
-      title: Secretary of Homeland Security
-      image: https://bixal.github.io/rrt-content/assets/img/Alejandro_Mayorkas.jpeg
-    - name: Michael Regan
-      title: Administrator of the Environmental Protection Agency
-      image: https://bixal.github.io/rrt-content/assets/img/Michael_Regan.jpeg
-    - name: Katherine Tai
-      title: United States Trade Representative
-      image: https://bixal.github.io/rrt-content/assets/img/Katherine_Tai.jpeg
-    - name: Linda Thomas-Greenfield
-      title: United States Ambassador to the United Nations
-      image: https://bixal.github.io/rrt-content/assets/img/Linda_Thomas-Greenfield.jpeg
-    - name: Dr. Cecilia Rouse
-      title: Chair of the Council of Economic Advisers
-      image: https://bixal.github.io/rrt-content/assets/img/Cecilia_Rouse.jpeg
-    - name: Isabel Guzman
-      title: Administrator of the Small Business Administration
-      image: https://bixal.github.io/rrt-content/assets/img/Isabel_Guzman.jpeg
+  - name: Marcia Fudge
+    title: Secretary of Housing and Urban Development
+    image: https://bixal.github.io/rrt-content/assets/img/Marcia_Fudge.jpeg
+  - name: Pete Buttigieg
+    title: Secretary of Transportation
+    image: https://bixal.github.io/rrt-content/assets/img/Pete_Buttigieg.jpeg
+  - name: Alejandro Mayorkas
+    title: Secretary of Homeland Security
+    image: https://bixal.github.io/rrt-content/assets/img/Alejandro_Mayorkas.jpeg
+  - name: Michael Regan
+    title: Administrator of the Environmental Protection Agency
+    image: https://bixal.github.io/rrt-content/assets/img/Michael_Regan.jpeg
+  - name: Katherine Tai
+    title: United States Trade Representative
+    image: https://bixal.github.io/rrt-content/assets/img/Katherine_Tai.jpeg
+  - name: Linda Thomas-Greenfield
+    title: United States Ambassador to the United Nations
+    image: https://bixal.github.io/rrt-content/assets/img/Linda_Thomas-Greenfield.jpeg
+  - name: Dr. Cecilia Rouse
+    title: Chair of the Council of Economic Advisers
+    image: https://bixal.github.io/rrt-content/assets/img/Cecilia_Rouse.jpeg
+  - name: Isabel Guzman
+    title: Administrator of the Small Business Administration
+    image: https://bixal.github.io/rrt-content/assets/img/Isabel_Guzman.jpeg
 source-domain: whitehouse.gov
 source-url: https://www.whitehouse.gov/administration/cabinet/
 breadcrumbs:


### PR DESCRIPTION
- uses mostly default USWDS component
- includes Home and current page by default
- allows for X number of custom links that can be set in page front matter

How to use:
1. add include to template
![image](https://user-images.githubusercontent.com/5177337/120844427-5b472c00-c53d-11eb-84d6-bf4a24ff6d81.png)
1. add ad-hoc breadcrumb link text and URLs to page front matter
![image](https://user-images.githubusercontent.com/5177337/120844471-6ac67500-c53d-11eb-9643-375882b71ca9.png)
1. enjoy!
![image](https://user-images.githubusercontent.com/5177337/120844514-7a45be00-c53d-11eb-9391-36cac099d83a.png)
