### PR TITLE
create youtube video template

### DIFF
--- a/_layouts/video.html
+++ b/_layouts/video.html
@@ -1,0 +1,22 @@
+<!doctype html>
+
+{% include head.html %}
+
+<body>
+  {% include header-extended.html %}
+
+  <main id="main-content">
+    <div class="grid-container padding-y-2">
+        {% include breadcrumb.html %}
+        <h1>{{ page.title }}</h1>
+        <div class="iframe-container">
+            <iframe class="responsive-iframe" src="https://www.youtube.com/embed/{{ page.youtube-id }}" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        </div>
+        <p class="text-base">{{ page.publish-date }}</p>
+        {{ content }}
+        <p>Source: <a href="{{ page.source-url }}" class="usa-link">{{ page.source-domain }}</a></p>
+    </div>
+  </main>
+
+  {% include footer.html %}
+  {% include foot.html %}

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,16 +1,35 @@
 body * {
-    font-family: "Public Sans Web", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !important;
-  }
-  
-  body {
-    font-size: 1.125rem;
-  }
-  
-  p, li, .usa-intro {
-    line-height: 1.5;
-  }
-  
-  h2, h3, h4, h5, h6 {
-    margin-top: 2rem;
-    margin-bottom: 1rem;
-  }
+  font-family: "Public Sans Web", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !important;
+}
+
+body {
+  font-size: 1.125rem;
+}
+
+p, li, .usa-intro {
+  line-height: 1.5;
+}
+
+h2, h3, h4, h5, h6 {
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+}
+
+/* responsive iframe approach from https://www.w3schools.com/ */
+.iframe-container {
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+  padding-top: 56.25%; /* 16:9 Aspect Ratio (divide 9 by 16 = 0.5625) */
+}
+
+/* Then style the iframe to fit in the container div with full height and width */
+.responsive-iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  width: 100%;
+  height: 100%;
+}

--- a/video.md
+++ b/video.md
@@ -1,0 +1,18 @@
+---
+layout: video
+template-title: Video
+template-description: Feature size YouTube video embed
+title: President Biden Answers Twitter Questions
+publish-date: Feb 19, 2021
+youtube-id: ODdRJSbXAVo
+source-domain: youtube.com
+source-url: https://www.youtube.com/watch?v=ODdRJSbXAVo
+breadcrumbs:
+  - name: Media
+    url: media.html
+  - name: Videos
+    url: media/videos.html
+---
+
+President Biden answers questions from Twitter on stimulus checks, vaccine production, and his morning routine, including making himself a cup of coffee.
+{: .maxw-tablet}


### PR DESCRIPTION
On a roll now...

- template allows for entering any youtube video id
- ad-hoc title and content
- custom css added to handle responsive video embed sizing (only 16:9 ratio for now)
- note separation of template title and content title; this will make creation of a template index page easier while allowing for real content

![image](https://user-images.githubusercontent.com/5177337/120854745-97818900-c54b-11eb-8e83-91fe971e6693.png)
