### PR TITLE
Added reusable code to about us page template

### DIFF
--- a/_layouts/about-us.html
+++ b/_layouts/about-us.html
@@ -1,0 +1,63 @@
+<!doctype html>
+
+{% include head.html %}
+
+<body>
+  {% include header-extended.html %}
+
+<main>
+<section>
+	<img src="https://raw.githubusercontent.com/Bixal/rrt-content/main/assets/img/waterboat.jpeg" alt="overhead shot of small row boat with passengers moving across clear water, from bottom to top">
+</section>
+
+<section class="grid-container margin-top-4 margin-bottom-4">
+	<h1 class="margin-top-0 tablet:margin-bottom-0">
+		{{ page.title }}
+	</h1>
+	<p class="usa-intro">
+		{{ content }}
+	</p>
+  </section>
+  <section class="usa-section usa-section--light">
+    <div class="grid-container">
+	   {% for value in page.values %}
+		  <div class="usa-media-block grid-col">
+	        <img class="usa-media-block__img margin-right-3 width-15" src="{{ value.image-source }}" alt="{{ value.alt-text }}">
+	        <div class="usa-media-block__body">
+	          <h3 class="margin-y-1">{{ value.topic }}</h3>
+	          <p class="margin-top-1">{{ value.description }}</p>
+	        </div>
+		  </div>
+	   {% endfor %}
+    </div>
+ </section>
+ <section>
+    <div class="grid-container">
+      <h2 id="leadership" class="font-heading-xl margin-top-6">Leadership</h2>
+       <div class="grid-row grid-gap">
+      	{% for staff in page.leadership %}
+      	  <div class="grid-col-4">
+            <img class="boem-leader-img" src="{{ staff.image-source }}" alt="{{ staff.alt-text }}">
+            <h3 class="margin-y-1">{{ staff.title }}</h3>
+            <a href="javascript:void(0)" class="usa-link margin-bottom-4">{{ staff.name }}</a>
+          </div>
+      	{% endfor %}
+       </div>
+
+      <h2 id="program-chiefs" class="font-heading-xl margin-top-6">Program Chiefs</h2>
+       <div class="grid-row grid-gap">
+      	{% for staff in page.program-chiefs %}
+      	  <div class="grid-col-4">
+            <img class="boem-leader-img" src="{{ staff.image-source }}" alt="{{ staff.alt-text }}">
+            <h3 class="margin-y-1">{{ staff.title }}</h3>
+            <a href="javascript:void(0)" class="usa-link margin-bottom-4">{{ staff.name }}</a>
+          </div>
+      	{% endfor %}
+   	   </div>
+   	  <p class="margin-y-5">Source: <a href="javascript:void(0)" class="usa-link">boem.gov</a></p>
+   	</div>
+  </section>
+</main>
+
+  {% include footer.html %}
+  {% include foot.html %}

--- a/_layouts/about-us.html
+++ b/_layouts/about-us.html
@@ -7,7 +7,7 @@
 
 <main id="main-content">
 <section>
-	<img src="https://raw.githubusercontent.com/Bixal/rrt-content/main/assets/img/waterboat.jpeg" alt="overhead shot of small row boat with passengers moving across clear water, from bottom to top">
+	<img src="{{ page.hero-img }}" class="width-full" alt="{{ page.hero-alt }}">
 </section>
 
 <section class="grid-container margin-top-4 margin-bottom-4">

--- a/_layouts/about-us.html
+++ b/_layouts/about-us.html
@@ -15,7 +15,7 @@
 		{{ page.title }}
 	</h1>
 	<p class="usa-intro">
-		{{ content }}
+		{{ page.description }}
 	</p>
   </section>
   <section class="usa-section usa-section--light">

--- a/_layouts/about-us.html
+++ b/_layouts/about-us.html
@@ -54,7 +54,7 @@
           </div>
       	{% endfor %}
    	   </div>
-   	  <p class="margin-y-5">Source: <a href="javascript:void(0)" class="usa-link">boem.gov</a></p>
+   	  <p class="margin-y-5">Source: <a href="{{ page.source-url }}" class="usa-link">{{ page.source-domain }}</a></p>
    	</div>
   </section>
 </main>

--- a/_layouts/about-us.html
+++ b/_layouts/about-us.html
@@ -5,7 +5,7 @@
 <body>
   {% include header-extended.html %}
 
-<main>
+<main id="main-content">
 <section>
 	<img src="https://raw.githubusercontent.com/Bixal/rrt-content/main/assets/img/waterboat.jpeg" alt="overhead shot of small row boat with passengers moving across clear water, from bottom to top">
 </section>

--- a/pages/about-us.md
+++ b/pages/about-us.md
@@ -4,6 +4,8 @@ template-title: About Us
 template-description: About Us page with company summary, values, and leadership profiles.
 title: About Boem
 description: About Us page with company summary, values, and leadership profiles.
+hero-img: https://raw.githubusercontent.com/Bixal/rrt-content/main/assets/img/waterboat.jpeg
+hero-alt: overhead shot of small row boat with passengers moving across clear water, from bottom to top
 values:
      - topic: Responsible Stewardship
        description: The bureau is responsible for the U.S. OCS energy and mineral resources, as well as protecting the environment the development may impact. These resources belong to the American people and future generations of Americans; wise use of and fair return for these resources are foremost in our management efforts.

--- a/pages/about-us.md
+++ b/pages/about-us.md
@@ -1,0 +1,47 @@
+---
+layout: about-us
+template-title: About Us
+template-description: About Us page with company summary and leadership profiles.
+title: About Boem
+description: About Us page with company summary and leadership profiles.
+values:
+     - topic: Responsible Stewardship
+       description: The bureau is responsible for the U.S. OCS energy and mineral resources, as well as protecting the environment the development may impact. These resources belong to the American people and future generations of Americans; wise use of and fair return for these resources are foremost in our management efforts.
+       image-source: https://raw.githubusercontent.com/Bixal/rrt-content/fb9fb47fe181172aaf1ed035aa485ea7c9285b1d/assets/img/icon-protect-water.svg
+       alt-text: An icon with a pair of hands surrounding a water droplet from below it.
+     - topic: Integrity and Ethics
+       description: As public servants, we adhere to fundamental principles of ethical behavior. In accordance with the examples set by BOEM leadership, each BOEM employee is expected to demonstrates both professional and personal integrity. This includes a commitment to the highest level of scientific and scholarly integrity.
+       image-source: https://raw.githubusercontent.com/Bixal/rrt-content/main/assets/img/icon-ethics.svg
+       alt-text: An icon showing a side proflie of a hand, palm-upwards, with a Scale of Justice above it.
+     - topic: Science-Informed Decisions
+       description: BOEM is committed to using the best available science in bureau decision making. To inform the wide range of decisions within the bureau, BOEM employs a significant number of scientists and technical experts across relevant disciplines to make sound decisions at all levels of the organization.
+       image-source: https://raw.githubusercontent.com/Bixal/rrt-content/main/assets/img/icon-science.svg
+       alt-text: An icon dipicting an atom. Three rings surround a small dot at the center.
+leadership:
+     - title: Director
+       name: Amanda Lefton
+       image-source: https://www.boem.gov/sites/default/files/styles/leadership/public/2021-03/LeftonAmanda_copyright-NY.jpg?itok=9LylxJ2G
+       alt-text: Headshot photo of Amanda Lefton with the American flag in the background
+     - title: Deputy Director
+       name: Walter Cruickshank, Ph.D.
+       image-source: https://www.boem.gov/sites/default/files/styles/leadership/public/2019-03/BOEM%20Dep.%20Director%20Photo.JPG?itok=K808AQi7
+       alt-text: Headshot photo of Walter Cruickshank with the American flag in the background
+program-chiefs:
+     - title: Budget & Program Coordination
+       name: James Anderson
+       image-source: https://www.boem.gov/sites/default/files/styles/leadership/public/2019-10/James%20Anderson.jpg?itok=TpwchbRD
+       alt-text: Headshot photo of James Anderson with the American flag in the background
+     - title: Stategic Resources
+       name: Dr. Megan Carr
+       image-source: https://www.boem.gov/sites/default/files/styles/leadership/public/2020-08/Megan%20Carr.jpg?itok=yqieVPfd
+       alt-text: Outdoors headshot photo of Dr. Megan Carr
+     - title: Environmental Program
+       name: William Yancey Brown
+       image-source: https://www.boem.gov/sites/default/files/styles/leadership/public/2019-10/Bill%20Brown.jpg?itok=dxGVQDCC
+       alt-text: Headshot photo of William Yancey with the American flag in the background
+source-domain: boem.gov
+source-url: https://www.boem.gov/about-boem
+figma: https://www.figma.com/file/s0zKIEPUh1k0oW4FDvVeIb/USWDS-Templates-Truss-Lib-v2.10.0?node-id=399%3A2542
+---
+
+The Mission of the Bureau of Ocean Energy Management is to manage development of U.S. Outer Continental Shelf energy and mineral resources in an environmentally and economically responsible way.

--- a/pages/about-us.md
+++ b/pages/about-us.md
@@ -1,9 +1,9 @@
 ---
 layout: about-us
 template-title: About Us
-template-description: About Us page with company summary and leadership profiles.
+template-description: About Us page with company summary, values, and leadership profiles.
 title: About Boem
-description: About Us page with company summary and leadership profiles.
+description: About Us page with company summary, values, and leadership profiles.
 values:
      - topic: Responsible Stewardship
        description: The bureau is responsible for the U.S. OCS energy and mineral resources, as well as protecting the environment the development may impact. These resources belong to the American people and future generations of Americans; wise use of and fair return for these resources are foremost in our management efforts.

--- a/pages/about-us.md
+++ b/pages/about-us.md
@@ -3,7 +3,7 @@ layout: about-us
 template-title: About Us
 template-description: About Us page with company summary, values, and leadership profiles.
 title: About Boem
-description: About Us page with company summary, values, and leadership profiles.
+description: The Mission of the Bureau of Ocean Energy Management is to manage development of U.S. Outer Continental Shelf energy and mineral resources in an environmentally and economically responsible way.
 hero-img: https://raw.githubusercontent.com/Bixal/rrt-content/main/assets/img/waterboat.jpeg
 hero-alt: overhead shot of small row boat with passengers moving across clear water, from bottom to top
 values:
@@ -45,5 +45,3 @@ source-domain: boem.gov
 source-url: https://www.boem.gov/about-boem
 figma: https://www.figma.com/file/s0zKIEPUh1k0oW4FDvVeIb/USWDS-Templates-Truss-Lib-v2.10.0?node-id=399%3A2542
 ---
-
-The Mission of the Bureau of Ocean Energy Management is to manage development of U.S. Outer Continental Shelf energy and mineral resources in an environmentally and economically responsible way.


### PR DESCRIPTION
Edit 6/25: I found a work-around; I used Philip's article page hero image as reference and that seemed to do the trick 🤗
- Issue with first section: background image does not fill full width. Any recommendations on how to fix this?
   - tried to use a different image but issue persist
   - tried inline style attribute but images not responsive 