### PR TITLE
add bg image url to front matter

### DIFF
--- a/_layouts/bio.html
+++ b/_layouts/bio.html
@@ -6,7 +6,7 @@
     {% include header-extended.html %}
 
     <main id="main-content">
-        <section class="usa-section" style="background-image:url(https://raw.githubusercontent.com/Bixal/rrt-content/main/assets/img/bio.jpg)">
+        <section class="usa-section" style="background-image:url({{ page.background-image }});">
             <div class="grid-container">
                 <h1 class="font-heading-3xl text-base-lightest">{{ page.title }}</h1>
             </div>

--- a/pages/bio.md
+++ b/pages/bio.md
@@ -14,6 +14,7 @@ breadcrumbs:
 profile-image: https://raw.githubusercontent.com/Bixal/rrt-content/main/assets/img/Bio-LeftonAmanda.jpg
 profile-image-alt: Headshot photo of Amanda Lefton with the American flag in the background
 figma: https://www.figma.com/file/s0zKIEPUh1k0oW4FDvVeIb/USWDS-Templates-Truss-Lib-v2.10.0?node-id=539%3A2296
+background-image: https://raw.githubusercontent.com/Bixal/rrt-content/main/assets/img/bio.jpg
 ---
 
 Prior to serving as the Director for BOEM, Amanda Lefton most recently served as the First Assistant Secretary for Energy and Environment for the Governor of New York where she led the State’s climate and environmental initiatives and managed a portfolio of twelve agencies and authorities. In this role she championed and advanced implementation of landmark nation leading climate and renewable energy strategies. Previously, Amanda was the Deputy Policy Director for The Nature Conservancy in New York, worked in the labor movement for the Rochester Regional Joint Board of Workers United, and for the New York State Assembly. She also worked for the State Senate.


### PR DESCRIPTION
closes #11

I looked at a few other options to avoid using the `style` tag in the template, which is not best CSS practice.

But it involved some less-than-ideal approaches of putting the image URLs either in the config file or the custom.css file or having to create some extra CSS files potentially.

So I think this is the simplest approach that keeps all the content for a template together in the related markdown file.

