### PR TITLE
Article side menu

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,7 +5,7 @@
     <meta name="description" content="{{ site.description }}">
     <meta name="viewport" content="width=device-width, initial-scale=1">
   
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/uswds/2.12.1/js/uswds.min.js" integrity="sha512-0I5hS86ISi9DRRJgArVIUFaI0fUpdxGppKIc6Dkl3NkdSNLwR2523QvMADILsfE1yK+nKbWuGDx+99+Fop3IgA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/uswds/2.12.1/css/uswds.min.css" integrity="sha512-wICx8of+w4Nz/tYsj4B6rYxkrkgOH8zJ7bcyaShiM7jMPtDVZGcMQz7EDaBIqpxu9XGvtR7RKeSj3Zp5pGrISQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/uswds/2.12.2/js/uswds.min.js" integrity="sha512-JZPbOlveyjzEUwcAJFmSQdxwz69XMfgQpXT5qqJ3jPwhyJu6FXeEcCzcpHgsV1kuj/5/VHgs1XyAoR3bmirXPQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/uswds/2.12.2/css/uswds.min.css" integrity="sha512-g4+SYZBxcfquMadzMxmKJiI7vZE69b6jZqZ2KtZQ9qNXVI8WSwFBlHJEL+rlqDhsBgSxuZsVzQ+cY1HMjpqa2g==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/custom.css">
   </head>

--- a/_layouts/article-side-menu.html
+++ b/_layouts/article-side-menu.html
@@ -1,0 +1,39 @@
+<!doctype html>
+
+{% include head.html %}
+
+<body>
+    {% include header-extended.html %}
+    <main id="main-content">
+        <img src="{{ page.hero-image }}" alt="{{ page.hero-image-alt }}" class="width-full">
+        <div class="grid-container">
+            <div class="grid-row grid-gap flex-align-start">
+                <div class="desktop:grid-col-3 tablet:order-{{ page.side-menu-order }} margin-y-3 position-sticky top-105">
+                    <nav aria-label="Secondary navigation,">
+                        <ul class="usa-sidenav">
+                            {% for item in page.side-menu %}
+                            <li class="usa-sidenav__item">
+                                <a href="#{{ item.id }}" class="{% if item.name == item.id %}usa-current{% endif %}">{{ item.name }}</a>
+                            </li>
+                            {% endfor %}
+                        </ul>
+                    </nav>
+                </div>
+                <div class="desktop:grid-col-9">
+                    <h1 class="font-heading-2xl">{{ page.title }}</h1>
+                    <p>{{ page.byline }}</p>
+                    <p>{{ page.dateline }}</p>
+                    <p>
+                        {% for item in page.labels %}
+                        <span class="usa-tag text-no-wrap">{{ item.name }}</span>
+                        {% endfor %}
+                    </p>
+                    {{ content }}
+                    <p>Source: <a href="{{ page.source-url }}" class="usa-link">{{ page.source-domain }}</a></p>
+                </div>
+            </div>
+        </div>
+    </main>
+
+    {% include footer.html %}
+    {% include foot.html %}

--- a/_layouts/article-side-menu.html
+++ b/_layouts/article-side-menu.html
@@ -7,13 +7,14 @@
     <main id="main-content">
         <img src="{{ page.hero-image }}" alt="{{ page.hero-image-alt }}" class="width-full">
         <div class="grid-container">
-            <div class="grid-row grid-gap flex-align-start">
-                <div class="desktop:grid-col-3 tablet:order-{{ page.side-menu-order }} margin-y-3 position-sticky top-105">
+            <div class="grid-row grid-gap flex-align-start">           
+                <div class="desktop:grid-col-3 tablet:order-{{ page.side-menu-order }} margin-y-3 position-sticky top-1">
                     <nav aria-label="Secondary navigation,">
                         <ul class="usa-sidenav">
                             {% for item in page.side-menu %}
                             <li class="usa-sidenav__item">
-                                <a href="#{{ item.id }}" class="{% if item.name == item.id %}usa-current{% endif %}">{{ item.name }}</a>
+                                <!--Should we include the usa-current class?-->
+                                <a href="#{{ item.id }}" class="{% if item.id == "understand-the-problem" %}usa-current{% endif %}">{{ item.name }}</a>
                             </li>
                             {% endfor %}
                         </ul>

--- a/pages/article-side-menu.md
+++ b/pages/article-side-menu.md
@@ -1,0 +1,104 @@
+---
+layout: article-side-menu
+template-title: Article with side menu
+template-description: Long form content with hero image, tags, a variety of typographical elements, and a side menu.
+title: Building a user-centered data strategy
+description: 18F can help agencies with the process of developing an effective data strategy. Our principles of user-centered design, agile, and iterative delivery can increase your agencies’ chance for success in using data more effectively.
+byline: "By Princess Ojiaku , Edwin Torres , Mark Headd"
+dateline: April 1, 2021
+labels:
+    - name: Data access
+    - name: User-centered design
+    - name: Agile
+side-menu-order: last #first for a left side menu or last for a right side menu
+side-menu:
+    - name: Understand the problem
+      id: understand-the-problem
+    - name: Let users be the guidepost
+      id: let-users-be-the-guideposts
+    - name: Work in an agile way
+      id: work-in-an-agile-way
+    - name: Leverage open resources
+      id: leverage-open-resources
+    - name: Get started
+      id: get-started
+source-domain: digital.gov
+source-url: https://18f.gsa.gov/2021/04/01/building_a_user-centered_data_strategy/
+hero-image: https://github.com/Bixal/rrt-content/blob/main/assets/img/farmer-on-tablet-usda.jpg?raw=true
+hero-image-alt: Farmer works on tablet with large tractor in the background
+figma: https://www.figma.com/file/QVPduB8h6DIENYULFVCism/?node-id=1101%3A3134
+---
+
+18F can help agencies with the process of developing an effective data strategy. Our principles of user-centered design, agile, and iterative delivery can increase your agencies’ chance for success in using data more effectively.
+{: .usa-intro}
+
+The Federal Government is one of the world’s biggest data producers. Finding, accessing, using, reusing, and protecting this data are challenges for which there have been several different initiatives during the past decade. The latest initiative is the [Federal Data Strategy](https://strategy.data.gov/){: .usa-link}, which provides a set of data principles and best practices in implementing data innovations that drive value for the public. This strategy includes an annual action plan for establishing processes, building capacity, and aligning existing efforts. Despite these guidelines and plans, it can be hard to know where to start when putting together a data strategy for your agency or organization.
+
+18F can assist agencies interested in developing a data strategy. Making a plan to effectively use data is rarely straightforward, and involves technical skills, excellent communication, change management, and iterative development.
+
+The 18F team has experience in this area. We have:
+
+- Assisted the Treasury Department [implement the DATA ACT](https://18f.gsa.gov/2016/06/14/prototype-early-prototype-often-lesson-from-the-data-act/){: .usa-link}
+- Helped federal laboratories [organize and share their data more effectively](https://18f.gsa.gov/2017/10/05/18f-and-federal-laboratories-work-together-to-bring-better-data-to-businesses/){: .usa-link} with industry partners
+- [Saved time and improved data quality](https://18f.gsa.gov/2020/04/23/saving-time-and-improving-data-quality-for-the-national-school-lunch-breakfast-program/){: .usa-link} for the National School Lunch & Breakfast Program.
+- Worked with many other agencies to help create sustainable data practices. We discuss some highlights of these projects below.
+
+We know from experience that each agency has diverse needs, resources, and maturity around data stewardship and related data skills.
+
+We believe that [our principles and methods for working with agencies](https://18f.gsa.gov/partnership-principles/){: .usa-link} are ideal for assisting with the challenges of developing a forward-thinking data strategy.
+
+Our approach to data projects is summed up in these principles:
+
+1. Understand the problem
+2. Let users be the guideposts
+3. Work in an agile way
+4. Leverage open resources
+
+## Understand the problem
+
+Developing a data strategy is challenging. The ever increasing availability of powerful new data tools, and the urgent need to derive new insights from data often results in a more tactical, less strategic approach. They know they want to do something, but often their specific goals are unclear.
+
+18F works with agencies to help them understand their current data and what they hope to achieve with it. This starts with user research, a process that helps us understand who produces and uses data. This user-centric approach ensures that agencies understand who the real users of data are, and what they actually need to do their jobs more effectively.
+
+As one example, the partnership between [18F and the USGS Water Resources Mission Area](https://18f.gsa.gov/2020/08/06/doing-user-research-to-design-the-next-gen-wdfn/){: .usa-link} partnered to understand their goals for making better use of data. They made use of the following user research questions:
+
+- What data are users looking for?
+- How are users finding their desired information?
+- What are user's workflows when using existing data sites? Are there any common flows or/ patterns that people take through existing data sites?
+- Are users getting the data they are looking for by the end of their journey?
+
+In another recent partnership with an Intelligence Community agency, 18F helped leadership and technical staff with actionable paths to improve data discovery and better serve the agency's mission. After extensive interviews with users, we recommended a data-centric product strategy paired with collaboration through working groups to support data development and maintenance. This environment creates opportunities for innovative data science and machine learning analytical capabilities.
+
+## Let users be the guideposts
+
+Human-centered design or user-centered design is a methodology that integrates feedback from the people for whom you are designing during the process. The goal of user-centered design is to create a solution that meets real people's needs, with minimal lost effort and reduced risk.
+
+User-centered design supports the development of a successful data strategy, through frequent and continuous end-user feedback during the design process. [Prototypes](https://methods.18f.gov/make/prototyping/){: .usa-link} are a way to get feedback from users, test hypotheses, and validate technology choices.
+
+Through work funded by [10x](https://10x.gsa.gov/){: .usa-link}, a team from [18F created mock-ups of a dashboard with personally identifiable information](https://18f.gsa.gov/2020/12/15/a-dashboard-for-privacy-offices/){: .usa-link} ([PII](https://ux-guide.18f.gov/research/privacy/#personally-identifiable-information-pii){: .usa-link}) maintained by government agencies. The team populated these prototypes with data and conducted user research with GSA's privacy office. 18F incorporated this feedback into the design of the prototype, allowing the team to adapt and save time during the design of the tool.
+
+## Work in an agile way
+
+Putting users at the center of an agency data strategy means we need to deliver value to these users quickly and often. The most effective way to develop a successful data strategy is to build it iteratively, learning from users as they make use of new opportunities to use data differently. Our approach is that a data strategy is not an outcome, but rather an ongoing process that is refined over time.
+
+18F works on data strategies with our partner agencies by using [agile](https://agile.18f.gov/agile-is-something-you-are/){: .usa-link} — a framework that focuses on iterative and continuous releases in a given timeframe. Agile encourages the delivery of small and frequent bits of value to end users, which is less costly and less risky to make changes as the team learns what users really need.
+
+As an example, 18F worked with the Federal Bureau of Investigation to [publicly release the nation's crime data](https://18f.gsa.gov/2017/09/07/opening-the-nations-crime-data/){: .usa-link}. The project's goals included applying open data principles to the FBI's data and building the tool for the public in a user-centered way. We wanted to make sure that the end product was useful, understandable, and accessible to everyone. We conducted user-testing sessions every two weeks to validate and iterate on our work, testing the tool with nearly 150 people inside and outside of the government.
+
+Agile and Human-centered design work together. They're more commonly used in software development, but are also useful for data-driven projects and strategies. This kind of work is needed regardless of the data maturity level of the agency. The combination of data expertise and iterative, user-centered development can — if pursued together — create the conditions for a user-oriented data strategy.
+
+## Leverage open resources
+
+Federal agencies are moving ahead with actions under the Federal Data Strategy plan to improve data management. This strategy includes:
+
+- The [Data Skills Catalog](https://resources.data.gov/assets/documents/fds-data-skills-catalog.pdf){: .usa-link},
+- The [Data Ethics Framework](https://resources.data.gov/assets/documents/fds-data-ethics-framework.pdf){: .usa-link}, and;
+- The repository [resources.data.gov,](https://resources.data.gov/){: .usa-link} which includes playbooks, templates, tools, and other resources.
+
+Agencies can use these resources to start their own data related initiatives. However, the above strategies cannot be used without modification: each organization has unique needs, users, and current approaches to data management which need to be taken into account. This means that these resources have to be adapted to every particular circumstance.
+
+Tailored data strategy plans have better chances of success if implemented in an iterative and agile way. A user-centered approach can guide and define the principles, ethics, and best practices for each agency.
+
+## Get started
+
+If your agency wants to make sure your data strategy brings maximum value to data users, we can help. Reach out to <inquiries18F@gsa.gov>{: .usa-link} to find out how 18F can help your agencies develop a world class data strategy.


### PR DESCRIPTION
Spent a ton of time in the position-sticky world and I am putting my white flag up. A few things:
- position-sticky for side menu not properly working on mobile (add as an issue to the repo if it can't be fixed?)
- `usa-current` class applied only to the first jump link...should we include this or omit it entirely? It looks a bit odd visually either way, but I can't quite figure out how to make this state active for a specific id(#) in Jekyll 🤔